### PR TITLE
Fix SAH Calculation.

### DIFF
--- a/Packages/ComputeShaderBVHMeshHit/Runtime/BvhBuilder.cs
+++ b/Packages/ComputeShaderBVHMeshHit/Runtime/BvhBuilder.cs
@@ -220,7 +220,7 @@ namespace ComputeShaderBvhMeshHit
             var bounds = CalcBounds(triangleBoundsArray);
 
             var size = bounds.size;
-            var sah = triangleBoundsArray.Length * (size.x * size.y + size.x * size.y + size.y * size.z);
+            var sah = triangleBoundsArray.Length * (size.x * size.y + size.y * size.z + size.z * size.x);
 
             return (bounds, sah);
         }


### PR DESCRIPTION
It appeared that the SAH calculation logic used for cost estimation in BVH splitting was incorrect, so I corrected it.